### PR TITLE
#93-ci: Nuevo script para reiniciar las bases de datos

### DIFF
--- a/bdClear.sh
+++ b/bdClear.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+python manage.py flush --no-input
+mongo --eval 'db.dropDatabase()' DOIT


### PR DESCRIPTION
# Cambios
- Añadido script para reiniciar la base de datos
# Test
- Primero dar permisos al script:
`chmod +x bdClear.sh`
- Ejecutar el script:
`./bdClear.sh`
- Comprobar que la base de datos se ha borrado por completo