### PR TITLE
Feature/#96 pager

### DIFF
--- a/doit/pagination.py
+++ b/doit/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class CustomPageNumberPagination(PageNumberPagination):
+    page_size_query_param = 'size'

--- a/doit/settings.py
+++ b/doit/settings.py
@@ -105,7 +105,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
         'auth.permissions.IsOwnerOrReadOnly',
     ],
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'doit.pagination.CustomPageNumberPagination',
     'PAGE_SIZE': 10
 }
 

--- a/frontend/src/components/atoms/card.tsx
+++ b/frontend/src/components/atoms/card.tsx
@@ -8,7 +8,7 @@ const Card = (props: {
   return (
     <article
       className={
-        "flex flex-col gap-3 overflow-hidden rounded-lg bg-white px-6 py-4 shadow-lg" +
+        "flex h-min flex-col gap-3 overflow-hidden rounded-lg bg-white px-6 py-4 shadow-lg" +
         (props.className ? " " + props.className : "")
       }
       onClick={props.onClick}

--- a/frontend/src/components/molecules/comment.tsx
+++ b/frontend/src/components/molecules/comment.tsx
@@ -4,15 +4,18 @@ import { socialService } from "services";
 import { SocialTypes } from "types";
 
 import { Card } from "components/atoms";
-import { UserTeaserReduced } from "components/organisms";
+import { UserAvatar, UserUsername } from "components/organisms";
 
 const Comment = (comment: SocialTypes.Comment) => {
   const { data: user } = socialService.useUser(comment.createdBy);
   return (
     <Card>
-      <div className="flex justify-between">
-        <Typography variant="body1">{comment.content}</Typography>
-        {user && <UserTeaserReduced {...user} />}
+      <div className="flex gap-3">
+        {user && <UserAvatar {...user} />}
+
+        <Typography variant="body1">
+          {user && <UserUsername {...user} />} : {comment.content}
+        </Typography>
       </div>
     </Card>
   );

--- a/frontend/src/components/molecules/dataLoader.tsx
+++ b/frontend/src/components/molecules/dataLoader.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { Alert, Button } from "@mui/material";
+import { Alert, Button, Divider } from "@mui/material";
 
 import { Loader, ParsedError } from "components/atoms";
 
@@ -8,6 +8,8 @@ const DataLoader = (props: {
   hasData?: boolean;
   error?: AxiosError | null;
   retry?: () => void;
+  hasNextPage?: boolean;
+  loadMore?: () => void;
 }) => {
   return (
     <>
@@ -32,6 +34,19 @@ const DataLoader = (props: {
         </Alert>
       )}
       {props.error && <ParsedError {...props.error} />}
+
+      {props.hasNextPage && (
+        <>
+          <Divider className="py-4" />
+          <Button
+            color="primary"
+            size="large"
+            onClick={() => !!props.loadMore && props.loadMore()}
+          >
+            Cargar más
+          </Button>
+        </>
+      )}
     </>
   );
 };

--- a/frontend/src/components/molecules/dataLoader.tsx
+++ b/frontend/src/components/molecules/dataLoader.tsx
@@ -10,6 +10,7 @@ const DataLoader = (props: {
   retry?: () => void;
   hasNextPage?: boolean;
   loadMore?: () => void;
+  topPositioned?: boolean;
 }) => {
   return (
     <>
@@ -37,7 +38,7 @@ const DataLoader = (props: {
 
       {props.hasNextPage && (
         <>
-          <Divider className="py-4" />
+          {!props.topPositioned && "bottom" && <Divider className="py-4" />}
           <div className="flex w-full justify-center">
             <Button
               color="primary"
@@ -47,6 +48,7 @@ const DataLoader = (props: {
               Cargar más
             </Button>
           </div>
+          {props.topPositioned && <Divider className="py-1" />}
         </>
       )}
     </>

--- a/frontend/src/components/molecules/dataLoader.tsx
+++ b/frontend/src/components/molecules/dataLoader.tsx
@@ -38,13 +38,15 @@ const DataLoader = (props: {
       {props.hasNextPage && (
         <>
           <Divider className="py-4" />
-          <Button
-            color="primary"
-            size="large"
-            onClick={() => !!props.loadMore && props.loadMore()}
-          >
-            Cargar más
-          </Button>
+          <div className="flex w-full justify-center">
+            <Button
+              color="primary"
+              size="large"
+              onClick={() => !!props.loadMore && props.loadMore()}
+            >
+              Cargar más
+            </Button>
+          </div>
         </>
       )}
     </>

--- a/frontend/src/components/organisms/commentSection.tsx
+++ b/frontend/src/components/organisms/commentSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Typography } from "@mui/material";
 
@@ -22,6 +22,10 @@ const CommentSection = (post: SocialTypes.Post) => {
     () => paginationUtils.combinePages(commentPages),
     [commentPages]
   );
+  const nOfComments = useMemo(
+    () => commentPages?.pages?.[0]?.count,
+    [commentPages]
+  );
 
   const [params, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -30,6 +34,16 @@ const CommentSection = (post: SocialTypes.Post) => {
       setSearchParams("");
     }
   }, [post.id, params, refetch, setSearchParams]);
+
+  const commentListRef = useRef<HTMLSelectElement>(null);
+  useEffect(() => {
+    if (!isLoading)
+      setTimeout(() => {
+        if (commentListRef.current)
+          commentListRef.current.scrollTop =
+            commentListRef.current.scrollHeight;
+      }, 100);
+  }, [isLoading]);
 
   return (
     <div className="flex flex-col gap-3">
@@ -40,23 +54,27 @@ const CommentSection = (post: SocialTypes.Post) => {
           </Typography>
           {post.id && (
             <PostCounters
-              comments={comments?.length || post.numComments}
+              comments={nOfComments || post.numComments}
               likes={post.likes}
               postId={post.id}
             />
           )}
         </div>
       </Card>
-      <section className="flex flex-col gap-3 overflow-auto py-2">
-        {comments?.map((comment) => (
-          <Comment key={comment.id} {...comment} />
-        ))}
+      <section
+        ref={commentListRef}
+        className="grid max-h-[420px] gap-3 overflow-auto py-2"
+      >
         <DataLoader
           isLoading={isLoading}
           hasData={!!comments?.length}
           hasNextPage={hasNextPage}
           loadMore={fetchNextPage}
+          topPositioned
         />
+        {comments?.reverse()?.map((comment) => (
+          <Comment key={comment.id} {...comment} />
+        ))}
       </section>
       <Card>
         <CommentForm postId={post.id} />

--- a/frontend/src/components/organisms/commentSection.tsx
+++ b/frontend/src/components/organisms/commentSection.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Typography } from "@mui/material";
 
 import { SocialTypes } from "types";
 import { socialService } from "services";
+import { paginationUtils } from "utils";
 
 import { Card } from "components/atoms";
 import { Comment, DataLoader, PostCounters } from "components/molecules";
@@ -11,10 +12,16 @@ import { CommentForm } from "components/templates";
 
 const CommentSection = (post: SocialTypes.Post) => {
   const {
-    data: commentList,
+    data: commentPages,
     isLoading,
     refetch,
+    hasNextPage,
+    fetchNextPage,
   } = socialService.usePostComments(post.id);
+  const comments = useMemo(
+    () => paginationUtils.combinePages(commentPages),
+    [commentPages]
+  );
 
   const [params, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -33,7 +40,7 @@ const CommentSection = (post: SocialTypes.Post) => {
           </Typography>
           {post.id && (
             <PostCounters
-              comments={commentList?.results?.length || post.numComments}
+              comments={comments?.length || post.numComments}
               likes={post.likes}
               postId={post.id}
             />
@@ -41,12 +48,14 @@ const CommentSection = (post: SocialTypes.Post) => {
         </div>
       </Card>
       <section className="flex flex-col gap-3 overflow-auto py-2">
-        {commentList?.results?.map((comment) => (
+        {comments?.map((comment) => (
           <Comment key={comment.id} {...comment} />
         ))}
         <DataLoader
           isLoading={isLoading}
-          hasData={!!commentList?.results?.length}
+          hasData={!!comments?.length}
+          hasNextPage={hasNextPage}
+          loadMore={fetchNextPage}
         />
       </section>
       <Card>

--- a/frontend/src/components/organisms/index.ts
+++ b/frontend/src/components/organisms/index.ts
@@ -6,12 +6,20 @@ import CommentSection from "./commentSection";
 // TEASERS
 import { GoalTeaser, GoalTeaserInfo, GoalTeaserReduced } from "./goalTeaser";
 import { PostTeaser } from "./postTeaser";
-import { UserTeaser, UserTeaserReduced, UserTeaserInfo } from "./userTeaser";
+import {
+  UserTeaser,
+  UserTeaserReduced,
+  UserTeaserInfo,
+  UserAvatar,
+  UserUsername,
+} from "./userTeaser";
 
 export {
   UserTeaser,
   UserTeaserInfo,
   UserTeaserReduced,
+  UserAvatar,
+  UserUsername,
   GoalTeaser,
   GoalTeaserInfo,
   GoalTeaserReduced,

--- a/frontend/src/components/organisms/postTeaser.tsx
+++ b/frontend/src/components/organisms/postTeaser.tsx
@@ -21,7 +21,7 @@ const PostTeaser = (post: SocialTypes.Post & { withoutComments?: boolean }) => {
   return (
     <div
       className={
-        "grid gap-4 lg:grid-cols-2 " +
+        "grid h-full gap-4 lg:grid-cols-2" +
         (post.withoutComments ? "!grid-cols-1" : "")
       }
     >
@@ -29,7 +29,7 @@ const PostTeaser = (post: SocialTypes.Post & { withoutComments?: boolean }) => {
         {goal && !isGoalDetail && !post.withoutComments && (
           <GoalTeaserReduced {...goal} />
         )}
-        <Card>
+        <Card className="h-full">
           <div className="-mx-7 -mt-5 flex items-center justify-between">
             {/* TODO: use real media photo */}
             <img
@@ -47,7 +47,7 @@ const PostTeaser = (post: SocialTypes.Post & { withoutComments?: boolean }) => {
           <section className="mb-4">
             <Typography variant="body1">{post.content}</Typography>
           </section>
-          <footer className="mb-auto flex justify-end">
+          <footer className="mt-auto flex justify-end">
             {post.withoutComments && post.id && (
               <PostCounters
                 comments={post.numComments}

--- a/frontend/src/components/organisms/userTeaser.tsx
+++ b/frontend/src/components/organisms/userTeaser.tsx
@@ -96,7 +96,7 @@ const UserTeaserInfo = (user: SocialTypes.User) => {
   };
 
   return (
-    <header className="flex w-full cursor-pointer items-center gap-2 md:gap-5">
+    <header className="flex w-full cursor-pointer flex-wrap items-center gap-2 md:gap-5">
       {/* TODO: use real media photo */}
       <Avatar
         alt="userimg"
@@ -104,12 +104,12 @@ const UserTeaserInfo = (user: SocialTypes.User) => {
         className="!h-[65px] !w-[65px] rounded-full border-2 border-gray-300 md:!h-[180px] md:!w-[180px]"
       />
 
-      <div className="flex items-center gap-3 rounded-full bg-gray-100 py-3 px-4 md:-ml-5 md:rounded-l-none md:pl-5">
+      <div className="flex items-center gap-3 rounded-full bg-gray-100 py-3 px-4 md:-ml-7 md:rounded-l-none md:pl-5">
         <Typography className="hover:font-bold" variant="h5">
           @{user.username}
         </Typography>
       </div>
-      <div className="flex items-center gap-3 rounded-full bg-gray-100 py-3 px-4 !text-lg">
+      <div className="flex items-center gap-3 rounded-full bg-gray-100 py-3 px-4">
         <UserCounters followers={user.numFollowers} posts={user.numPosts} />
       </div>
       {!isMyProfile && (
@@ -146,4 +146,34 @@ const UserTeaserReduced = (user: SocialTypes.User) => {
   );
 };
 
-export { UserTeaserReduced, UserTeaser, UserTeaserInfo };
+const UserUsername = (user: SocialTypes.User) => {
+  const navigate = useNavigate();
+  const onOpenUser = () => navigate("/users/" + user.id + "/info");
+  return (
+    <strong className="cursor-pointer hover:!underline" onClick={onOpenUser}>
+      @{user.username}
+    </strong>
+  );
+};
+
+const UserAvatar = (user: SocialTypes.User) => {
+  const navigate = useNavigate();
+  const onOpenUser = () => navigate("/users/" + user.id + "/info");
+
+  return (
+    <Avatar
+      onClick={onOpenUser}
+      className="-ml-3 cursor-pointer"
+      alt="userimg"
+      src="https://placekitten.com/1000/1000"
+    />
+  );
+};
+
+export {
+  UserTeaserReduced,
+  UserTeaser,
+  UserTeaserInfo,
+  UserUsername,
+  UserAvatar,
+};

--- a/frontend/src/components/templates/tabs/goalTabs.tsx
+++ b/frontend/src/components/templates/tabs/goalTabs.tsx
@@ -6,12 +6,12 @@ import { Button, Divider, Typography } from "@mui/material";
 import { useActiveUser, useNotificationStore } from "store";
 import { goalService, socialService } from "services";
 import { GoalTypes } from "types";
-import { texts } from "utils";
+import { paginationUtils, texts } from "utils";
 
 import { ParsedError } from "components/atoms";
 import { DataLoader, ProgressBar } from "components/molecules";
-import { GoalForm, ObjectivesForm } from "components/templates";
 import { PostTeaser } from "components/organisms";
+import { GoalForm, ObjectivesForm } from "components/templates";
 
 const GoalInfoTab = (goal: GoalTypes.Goal) => {
   const navigate = useNavigate();
@@ -219,11 +219,15 @@ const GoalInfoTab = (goal: GoalTypes.Goal) => {
 const GoalFeedTab = (goal: GoalTypes.Goal) => {
   const navigate = useNavigate();
   const {
-    data: goalPostList,
+    data: goalPages,
     isLoading,
     refetch,
     error,
   } = socialService.useGoalPosts(goal.id);
+  const goals = useMemo(
+    () => paginationUtils.combinePages(goalPages),
+    [goalPages]
+  );
 
   const [params, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -249,12 +253,12 @@ const GoalFeedTab = (goal: GoalTypes.Goal) => {
       </div>
       <DataLoader
         isLoading={isLoading}
-        hasData={!!goalPostList?.results?.length}
+        hasData={!!goals?.length}
         retry={refetch}
         error={error}
       />
       <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {goalPostList?.results?.map((post) => (
+        {goals?.map((post) => (
           <PostTeaser withoutComments key={post.id} {...post} />
         ))}
       </div>

--- a/frontend/src/components/templates/tabs/userTabs.tsx
+++ b/frontend/src/components/templates/tabs/userTabs.tsx
@@ -5,6 +5,7 @@ import { Button, Typography } from "@mui/material";
 import { socialService } from "services";
 import { SocialTypes } from "types";
 import { useActiveUser } from "store";
+import { paginationUtils } from "utils";
 
 import { DataLoader } from "components/molecules";
 import { PostTeaser } from "components/organisms";
@@ -30,7 +31,13 @@ const UserFeedTab = (user: SocialTypes.User) => {
     isLoading,
     refetch,
     error,
+    hasNextPage,
+    fetchNextPage,
   } = socialService.useUserPosts(user.id);
+  const posts = useMemo(
+    () => paginationUtils.combinePages(userPostList),
+    [userPostList]
+  );
 
   const [params, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -48,17 +55,19 @@ const UserFeedTab = (user: SocialTypes.User) => {
           <Button onClick={() => navigate("new-post")}>Nuevo</Button>
         </div>
       )}
-      <DataLoader
-        isLoading={isLoading}
-        hasData={!!userPostList?.results?.length}
-        retry={refetch}
-        error={error}
-      />
       <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {userPostList?.results?.map((post) => (
+        {posts?.map((post) => (
           <PostTeaser withoutComments key={post.id} {...post} />
         ))}
       </div>
+      <DataLoader
+        isLoading={isLoading}
+        hasData={!!posts?.length}
+        retry={refetch}
+        error={error}
+        hasNextPage={hasNextPage}
+        loadMore={fetchNextPage}
+      />
     </section>
   );
 };

--- a/frontend/src/layout/page.tsx
+++ b/frontend/src/layout/page.tsx
@@ -11,7 +11,10 @@ const Page = (props: {
       <section className="block animate-fade-in xl:w-3/4">
         <section className="flex flex-col justify-between gap-y-2 md:mb-7 md:flex-row md:items-center">
           {props.title && (
-            <Typography variant="h3" className="overflow-hidden text-ellipsis">
+            <Typography
+              variant="h3"
+              className="overflow-hidden text-ellipsis text-center md:text-left"
+            >
               {props.title}
             </Typography>
           )}

--- a/frontend/src/pages/explore.tsx
+++ b/frontend/src/pages/explore.tsx
@@ -26,14 +26,14 @@ const ExplorePage = () => {
   );
 
   const {
-    data: postList,
+    data: postPages,
     isLoading: loadingPosts,
     error: postError,
     isError: isPostError,
   } = socialService.usePosts();
   const posts = useMemo(
-    () => paginationUtils.combinePages(postList),
-    [postList]
+    () => paginationUtils.combinePages(postPages),
+    [postPages]
   );
 
   const {

--- a/frontend/src/pages/explore.tsx
+++ b/frontend/src/pages/explore.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { Typography } from "@mui/material";
 import Carousel from "react-material-ui-carousel";
 import { AxiosError } from "axios";
@@ -6,7 +6,7 @@ import { AxiosError } from "axios";
 import { Page } from "layout";
 import { useNotificationStore } from "store";
 import { goalService, socialService } from "services";
-import { arrayUtils } from "utils";
+import { arrayUtils, paginationUtils } from "utils";
 
 import { DataLoader } from "components/molecules";
 import { GoalTeaserInfo, PostTeaser, UserTeaser } from "components/organisms";
@@ -15,11 +15,15 @@ const ExplorePage = () => {
   const { addNotification } = useNotificationStore();
 
   const {
-    data: goalList,
+    data: goalPages,
     isLoading: loadingGoals,
     error: goalError,
     isError: isGoalError,
   } = goalService.useGoals();
+  const goals = useMemo(
+    () => paginationUtils.combinePages(goalPages),
+    [goalPages]
+  );
 
   const {
     data: postList,
@@ -27,13 +31,21 @@ const ExplorePage = () => {
     error: postError,
     isError: isPostError,
   } = socialService.usePosts();
+  const posts = useMemo(
+    () => paginationUtils.combinePages(postList),
+    [postList]
+  );
 
   const {
-    data: userList,
+    data: userPages,
     isLoading: loadingUsers,
     error: userError,
     isError: isUserError,
   } = socialService.useUsers();
+  const users = useMemo(
+    () => paginationUtils.combinePages(userPages),
+    [userPages]
+  );
 
   useEffect(() => {
     if (isGoalError) {
@@ -56,7 +68,7 @@ const ExplorePage = () => {
             loading={loadingGoals}
             error={isGoalError ? goalError : undefined}
             slides={
-              goalList?.results?.map((goal) => (
+              goals?.map((goal) => (
                 <GoalTeaserInfo key={goal.id} {...goal} />
               )) || []
             }
@@ -67,9 +79,8 @@ const ExplorePage = () => {
             loading={loadingUsers}
             error={isUserError ? userError : undefined}
             slides={
-              userList?.results?.map((user) => (
-                <UserTeaser key={user.id} {...user} />
-              )) || []
+              users?.map((user) => <UserTeaser key={user?.id} {...user} />) ||
+              []
             }
           />
 
@@ -78,7 +89,7 @@ const ExplorePage = () => {
             loading={loadingPosts}
             error={isPostError ? postError : undefined}
             slides={
-              postList?.results?.map((post) => (
+              posts?.map((post) => (
                 <PostTeaser withoutComments key={post.id} {...post} />
               )) || []
             }

--- a/frontend/src/pages/feed.tsx
+++ b/frontend/src/pages/feed.tsx
@@ -6,6 +6,7 @@ import { Page } from "layout";
 import { socialService } from "services";
 import { useActiveUser } from "store";
 import { SocialTypes } from "types";
+import { paginationUtils } from "utils";
 
 import { DataLoader } from "components/molecules";
 import { ModalDrawer, PostTeaser } from "components/organisms";
@@ -22,13 +23,8 @@ const FeedPage = () => {
     fetchNextPage,
     hasNextPage,
   } = socialService.useFeedPosts(activeUser?.id);
-
   const posts = useMemo(
-    () =>
-      postPages?.pages?.reduce(
-        (acc, page) => acc.concat(page?.results),
-        [] as SocialTypes.Post[]
-      ),
+    () => paginationUtils.combinePages(postPages),
     [postPages]
   );
 

--- a/frontend/src/pages/feed.tsx
+++ b/frontend/src/pages/feed.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
 import { Button, Typography } from "@mui/material";
 
@@ -15,10 +15,22 @@ const FeedPage = () => {
   const { activeUser } = useActiveUser();
 
   const {
-    data: postList,
+    data: postPages,
     isLoading: loadingPosts,
+    isFetchingNextPage,
     refetch,
+    fetchNextPage,
+    hasNextPage,
   } = socialService.useFeedPosts(activeUser?.id);
+
+  const posts = useMemo(
+    () =>
+      postPages?.pages?.reduce(
+        (acc, page) => acc.concat(page?.results),
+        [] as SocialTypes.Post[]
+      ),
+    [postPages]
+  );
 
   const navigate = useNavigate();
 
@@ -34,16 +46,18 @@ const FeedPage = () => {
           <Typography variant="h5">Últimos posts</Typography>
           <Button onClick={() => navigate("/feed/new-post")}>Nuevo</Button>
         </div>
-        <DataLoader
-          isLoading={loadingPosts}
-          hasData={!!postList?.results?.length}
-          retry={refetch}
-        />
         <div className="flex flex-col gap-10">
-          {postList?.results?.map((post) => (
+          {posts?.map((post) => (
             <PostTeaserProvider key={post.id} {...post} />
           ))}
         </div>
+        <DataLoader
+          isLoading={loadingPosts || isFetchingNextPage}
+          hasData={!!posts?.length}
+          retry={refetch}
+          hasNextPage={hasNextPage}
+          loadMore={fetchNextPage}
+        />
         <FeedModals />
       </div>
     </Page>

--- a/frontend/src/pages/goalDetails.tsx
+++ b/frontend/src/pages/goalDetails.tsx
@@ -69,7 +69,10 @@ const GoalDetailPage = () => {
     <Page title={goal?.title || "Objetivo sin título"}>
       <div className="flex flex-col gap-3">
         <div className="flex flex-col justify-between gap-3 md:flex-row md:items-center">
-          <Typography variant="h5">
+          <Typography
+            variant="h5"
+            className="order-2 !text-center md:-order-1 md:text-left"
+          >
             {labels[activeTab as GoalTabsType]}
           </Typography>
 
@@ -77,7 +80,6 @@ const GoalDetailPage = () => {
             value={activeTab}
             onChange={handleChange}
             variant="scrollable"
-            scrollButtons
             allowScrollButtonsMobile
           >
             <Tab value={"info"} icon={<InfoOutlined />} />

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
 import { Button, Skeleton, Typography } from "@mui/material";
 
@@ -6,6 +6,7 @@ import { Page } from "layout";
 import { goalService } from "services";
 import { GoalTypes } from "types";
 import { useActiveUser } from "store";
+import { paginationUtils } from "utils";
 
 import { DataLoader } from "components/molecules";
 import { GoalTeaser, ModalDrawer } from "components/organisms";
@@ -15,10 +16,14 @@ const HomePage = () => {
   const { activeUser } = useActiveUser();
 
   const {
-    data: goalList,
+    data: goalPages,
     isLoading: loadingGoals,
     refetch,
   } = goalService.useGoalsByParticipant(activeUser?.id);
+  const goals = useMemo(
+    () => paginationUtils.combinePages(goalPages),
+    [goalPages]
+  );
 
   const navigate = useNavigate();
 
@@ -42,11 +47,11 @@ const HomePage = () => {
 
         <DataLoader
           isLoading={loadingGoals}
-          hasData={!!goalList?.results?.length}
+          hasData={!!goals?.length}
           retry={refetch}
         />
 
-        {goalList?.results?.map((goal) => (
+        {goals?.map((goal) => (
           <GoalTeaserProvider {...goal} />
         ))}
       </div>

--- a/frontend/src/pages/userDetails.tsx
+++ b/frontend/src/pages/userDetails.tsx
@@ -68,7 +68,10 @@ const UserDetailPage = () => {
           <>
             <UserTeaserInfo {...user} />
             <div className="mt-5 flex flex-col justify-between gap-3 md:flex-row md:items-center">
-              <Typography variant="h5">
+              <Typography
+                variant="h5"
+                className="order-2 !text-center md:-order-1 md:text-left"
+              >
                 {labels[activeTab as UserTabsType]}
               </Typography>
 
@@ -76,7 +79,6 @@ const UserDetailPage = () => {
                 value={activeTab}
                 onChange={handleChange}
                 variant="scrollable"
-                scrollButtons
                 allowScrollButtonsMobile
               >
                 <Tab value={"info"} icon={<InfoOutlined />} />

--- a/frontend/src/services/goalService.ts
+++ b/frontend/src/services/goalService.ts
@@ -10,7 +10,7 @@ import { axiosInstance } from "./config";
 const requests = {
   getGoals: (page?: number) =>
     axiosInstance
-      .get("/goal/" + (page ? "?page=" + page : ""))
+      .get("/goal/?size=9" + (page ? "&page=" + page : ""))
       .then((response) => response.data),
 
   getGoalsByParticipant: (participantId?: Id, page?: number) =>

--- a/frontend/src/services/goalService.ts
+++ b/frontend/src/services/goalService.ts
@@ -1,17 +1,25 @@
 import { AxiosError } from "axios";
-import { useMutation, useQuery } from "react-query";
+import { useInfiniteQuery, useMutation, useQuery } from "react-query";
 
 import { GoalTypes } from "types";
 import { Id, PagedList } from "types/apiTypes";
+import { paginationUtils } from "utils";
 
 import { axiosInstance } from "./config";
 
 const requests = {
-  getGoals: () => axiosInstance.get("/goal/").then((response) => response.data),
-
-  getGoalsByParticipant: (participantId?: Id) =>
+  getGoals: (page?: number) =>
     axiosInstance
-      .get("/goal/?participant=" + (participantId || "missing"))
+      .get("/goal/" + (page ? "?page=" + page : ""))
+      .then((response) => response.data),
+
+  getGoalsByParticipant: (participantId?: Id, page?: number) =>
+    axiosInstance
+      .get(
+        "/goal/?participant=" +
+          (participantId || "missing") +
+          (page ? "&page=" + page : "")
+      )
       .then((response) => response.data),
 
   getGoal: (id?: Id) =>
@@ -85,14 +93,23 @@ const goalService = {
   // GOALS
   // Use all the goals
   useGoals: () =>
-    useQuery<PagedList<GoalTypes.Goal>, AxiosError>("goals", () =>
-      requests.getGoals()
+    useInfiniteQuery<PagedList<GoalTypes.Goal>, AxiosError>(
+      "goals",
+      ({ pageParam = 0 }) => requests.getGoals(pageParam),
+      {
+        getNextPageParam: paginationUtils.getNextPage,
+      }
     ),
 
   // Use my goals
   useGoalsByParticipant: (participantId?: Id) =>
-    useQuery<PagedList<GoalTypes.Goal>, AxiosError>("my-goals", () =>
-      requests.getGoalsByParticipant(participantId)
+    useInfiniteQuery<PagedList<GoalTypes.Goal>, AxiosError>(
+      `participant-${participantId}-goals`,
+      ({ pageParam = 0 }) =>
+        requests.getGoalsByParticipant(participantId, pageParam),
+      {
+        getNextPageParam: paginationUtils.getNextPage,
+      }
     ),
 
   // Use a goal specifying its id

--- a/frontend/src/services/socialService.ts
+++ b/frontend/src/services/socialService.ts
@@ -10,7 +10,7 @@ import { axiosInstance } from "./config";
 const requests = {
   getUsers: (page?: number) =>
     axiosInstance
-      .get("/user/" + (page ? "?page=" + page + "/" : ""))
+      .get("/user/?size=9" + (page ? "&page=" + page + "/" : ""))
       .then((response) => response.data),
 
   getUser: (id?: Id) =>
@@ -46,6 +46,7 @@ const requests = {
         "/post/?goal=" +
           (goalId || "missing") +
           "&order_by=-creationDate" +
+          "&size=9" +
           (page ? "&page=" + page : "")
       )
       .then((response) => response.data),
@@ -56,13 +57,16 @@ const requests = {
         "/post/?createdBy=" +
           (userId || "missing") +
           "&order_by=-creationDate" +
+          "&size=9" +
           (page ? "&page=" + page : "")
       )
       .then((response) => response.data),
 
   getPosts: (page?: number) =>
     axiosInstance
-      .get("/post/?order_by=-creationDate" + (page ? "?page=" + page : ""))
+      .get(
+        "/post/?order_by=-creationDate&size=9" + (page ? "?page=" + page : "")
+      )
       .then((response) => response.data),
 
   createPost: (post: SocialTypes.Post) =>
@@ -73,7 +77,8 @@ const requests = {
       .get(
         "/comment/?post=" +
           (postId || "missing") +
-          "&order_by=creationDate" +
+          "&order_by=-creationDate" +
+          "&size=5" +
           (page ? "&page=" + page : "")
       )
       .then((response) => response.data),

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -6,7 +6,8 @@
 @tailwind components;
 /* Stop purging. */
 
-.MuiButton-text {
+.MuiButton-text,
+.MuiButton-outlined {
   @apply !font-bold;
 }
 
@@ -18,10 +19,27 @@
   @apply !text-black;
 }
 
+.css-12sazjn-MuiButtonBase-root-MuiTab-root {
+  @apply !min-w-0 !px-3;
+}
+
+.MuiTabs-flexContainer {
+  @apply justify-center;
+}
+
 /* Your own custom component styles */
 
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */
+
+*::-webkit-scrollbar {
+  @apply mx-2 my-1 w-1 rounded-xl bg-gray-100;
+}
+
+*::-webkit-scrollbar-thumb {
+  @apply mx-2 my-1 rounded-xl bg-primary opacity-60;
+  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.1);
+}
 
 /* Your own custom utilities */

--- a/frontend/src/types/apiTypes.ts
+++ b/frontend/src/types/apiTypes.ts
@@ -2,7 +2,7 @@ export type Id = number | string;
 
 export type PagedList<ItemType> = {
   count: number;
-  next: string;
-  previous: string;
+  next: string | null;
+  previous: string | null;
   results: ItemType[];
 };

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,6 @@
 import formParsers from "./formParsers";
 import texts from "./contentTexts";
 import arrayUtils from "./arrayUtils";
+import paginationUtils from "./paginationUtils";
 
-export { formParsers, texts, arrayUtils };
+export { formParsers, texts, arrayUtils, paginationUtils };

--- a/frontend/src/utils/paginationUtils.ts
+++ b/frontend/src/utils/paginationUtils.ts
@@ -1,0 +1,15 @@
+import { InfiniteData } from "react-query";
+import { PagedList } from "types/apiTypes";
+
+const paginationUtils = {
+  getNextPage: (lastPage: PagedList<any>) =>
+    lastPage.next?.split("page=").pop(),
+
+  combinePages: (pageObject?: InfiniteData<PagedList<any>>) =>
+    pageObject?.pages?.reduce(
+      (acc, page) => acc.concat(page?.results),
+      [] as any[]
+    ),
+};
+
+export default paginationUtils;


### PR DESCRIPTION
## cambios
- implementado el paginador para listas de contenido
- paginador de tipo "load more"
- uso en las diferentes listas de la app
- ordenar listados por fecha (comentarios es inverso)

## test
- comprueba el feed, sigue a varios usuario o crea muchos posts con uno y siguelo con otro
- scroll down
- click en "cargar más"
- comprueba otras listas, feed de goal/user, listado de goals, comments ...

## preocupaciones
- hay casos en los que convendría poder especificar el tamño de pagina de forma concreta
- es posible? @pedalopon 