### PR TITLE
#29-feat: leaderboard

### DIFF
--- a/doit/urls.py
+++ b/doit/urls.py
@@ -48,7 +48,7 @@ router.register(r'tracking', TrackingViewSet, "tracking")
 urlpatterns = [
     # Customs endpoints
     path('api/goal/<str:goal_id>/my-progress', GoalProgress.as_view()),
-    path('api/goal/<str:goal_id>/leader-board', LeaderBoard.as_view()),
+    path('api/goal/<str:goal_id>/leaderboard', LeaderBoard.as_view()),
     path('api/goal/<goal_id>/is-participating', UserIsParticipating.as_view()),
     path('api/media/', MediaUploadApi.as_view()),
     path('api/media/<media_id>', MediaApi.as_view()),

--- a/doit/urls.py
+++ b/doit/urls.py
@@ -23,7 +23,7 @@ from auth.googleOAuth2Adapter import GoogleLogin
 from doit.settings import MEDIA_ROOT, MEDIA_URL
 from doit.views import PopulateDB
 from frontend.views import app
-from goals.views import GoalViewSet, ObjectiveViewSet, TrackingViewSet, GoalProgress
+from goals.views import GoalViewSet, ObjectiveViewSet, TrackingViewSet, GoalProgress, LeaderBoard
 from media.views import MediaUploadApi, MediaApi
 from social.views import PostViewSet, UserViewSet, NotificationViewSet, FollowViewSet, ParticipateViewSet, \
     LikePostViewSet, LikeTrackingViewSet, CommentViewSet, UserIsParticipating
@@ -48,6 +48,7 @@ router.register(r'tracking', TrackingViewSet, "tracking")
 urlpatterns = [
     # Customs endpoints
     path('api/goal/<str:goal_id>/my-progress', GoalProgress.as_view()),
+    path('api/goal/<str:goal_id>/leader-board', LeaderBoard.as_view()),
     path('api/goal/<goal_id>/is-participating', UserIsParticipating.as_view()),
     path('api/media/', MediaUploadApi.as_view()),
     path('api/media/<media_id>', MediaApi.as_view()),

--- a/frontend/src/components/molecules/progressBar.tsx
+++ b/frontend/src/components/molecules/progressBar.tsx
@@ -1,14 +1,14 @@
 import { LinearProgress } from "@mui/material";
 
 const ProgressBar = (props: {
-  title: string;
+  title?: string;
   completed: number;
   objective: number;
   expected?: number;
 }) => {
   return (
     <div className="flex flex-wrap items-center justify-between gap-1 text-base text-gray-700">
-      <span>{props.title}</span>
+      {props.title && <span>{props.title}</span>}
       <span>
         {props.completed} / {props.objective}
       </span>

--- a/frontend/src/components/organisms/followTable.tsx
+++ b/frontend/src/components/organisms/followTable.tsx
@@ -4,11 +4,11 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import Paper from "@mui/material/Paper";
 
 import { useActiveUser } from "store";
 import { SocialTypes } from "types";
 
+import { Card } from "components/atoms";
 import { FollowButton } from "components/molecules";
 import { UserAvatar, UserUsername } from "components/organisms";
 
@@ -16,7 +16,7 @@ const FollowTable = (props: { users: SocialTypes.User[] }) => {
   const { activeUser } = useActiveUser();
 
   return (
-    <TableContainer component={Paper}>
+    <TableContainer component={Card}>
       <Table sx={{ minWidth: 650 }} aria-label="simple table">
         <TableHead>
           <TableRow>

--- a/frontend/src/components/organisms/goalTeaser.tsx
+++ b/frontend/src/components/organisms/goalTeaser.tsx
@@ -81,7 +81,10 @@ const GoalTeaserReduced = (goal: GoalTypes.Goal) => {
   const onOpenGoal = () => navigate("/goals/" + goal.id + "/info");
 
   return (
-    <Card className="cursor-pointer" onClick={onOpenGoal}>
+    <Card
+      className="min-h-[calc(32px+40px)] cursor-pointer"
+      onClick={onOpenGoal}
+    >
       <header className="flex items-center justify-between">
         <Typography variant="h5">
           <strong>{goal.title}</strong>

--- a/frontend/src/components/organisms/index.ts
+++ b/frontend/src/components/organisms/index.ts
@@ -5,6 +5,7 @@ import CommentSection from "./commentSection";
 
 // Tables
 import FollowTable from "./followTable";
+import LeaderboardTable from "./leaderboardTable";
 
 // TEASERS
 import { GoalTeaser, GoalTeaserInfo, GoalTeaserReduced } from "./goalTeaser";
@@ -33,4 +34,5 @@ export {
   ModalDrawer,
   CommentSection,
   FollowTable,
+  LeaderboardTable,
 };

--- a/frontend/src/components/organisms/leaderboardTable.tsx
+++ b/frontend/src/components/organisms/leaderboardTable.tsx
@@ -1,0 +1,98 @@
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import {
+  Cancel,
+  CheckCircle,
+  EmojiEvents,
+  MilitaryTech,
+  MilitaryTechOutlined,
+} from "@mui/icons-material";
+
+import { useActiveUser } from "store";
+import { SocialTypes } from "types";
+
+import { FollowButton, ProgressBar } from "components/molecules";
+import { UserAvatar, UserUsername } from "components/organisms";
+import { Card } from "components/atoms";
+
+const LeaderboardTable = (props: {
+  users: (SocialTypes.User & { amount: number })[];
+  objective?: number;
+}) => {
+  const { activeUser } = useActiveUser();
+
+  const getPosition = (user: SocialTypes.User & { amount: number }) => {
+    switch (props.users.indexOf(user) + 1) {
+      case 1:
+        return <EmojiEvents fontSize="large" className="!fill-yellow-400" />;
+      case 2:
+        return <MilitaryTech fontSize="large" className="!fill-gray-300" />;
+      case 3:
+        return (
+          <MilitaryTechOutlined fontSize="large" className="!fill-yellow-700" />
+        );
+      default:
+        return props.users.indexOf(user) + 1;
+    }
+  };
+
+  return (
+    <TableContainer component={Card}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell align="center">Posición</TableCell>
+            <TableCell>Foto</TableCell>
+            <TableCell>Usuario</TableCell>
+            <TableCell>Progreso</TableCell>
+            <TableCell align="center">Completado</TableCell>
+            <TableCell align="center">Seguir</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {props.users?.map((user) => {
+            const isActiveUser = activeUser?.id === user?.id;
+            return (
+              <TableRow
+                key={user.id}
+                sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+              >
+                <TableCell align="center" scope="row" className="text-lg">
+                  {getPosition(user)}
+                </TableCell>
+                <TableCell align="center" scope="row">
+                  <UserAvatar {...user} />
+                </TableCell>
+                <TableCell scope="row">
+                  <UserUsername {...user} />
+                </TableCell>
+                <TableCell>
+                  <ProgressBar
+                    objective={props.objective || 0}
+                    completed={user.amount}
+                  />
+                </TableCell>
+                <TableCell align="center">
+                  {user.amount >= (props.objective || 0) ? (
+                    <CheckCircle color="primary" />
+                  ) : (
+                    <Cancel color="error" />
+                  )}
+                </TableCell>
+                <TableCell align="center">
+                  {!isActiveUser && <FollowButton {...user} />}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default LeaderboardTable;

--- a/frontend/src/components/organisms/postTeaser.tsx
+++ b/frontend/src/components/organisms/postTeaser.tsx
@@ -35,11 +35,15 @@ const PostTeaser = (post: SocialTypes.Post & { withoutComments?: boolean }) => {
               <Image src={post.urlMedia} alt={post.title} />
             </div>
           )}
-          <header className="flex items-center justify-between">
+          <header className="flex flex-wrap-reverse items-center justify-between gap-3">
             <Typography variant="h5">
               <strong>{post.title}</strong>
             </Typography>
-            {user && <UserTeaserReduced {...user} />}
+            {user && (
+              <div className="ml-auto">
+                <UserTeaserReduced {...user} />
+              </div>
+            )}
           </header>
           <section className="mb-4">
             <Typography variant="body1">{post.content}</Typography>

--- a/frontend/src/components/organisms/userTeaser.tsx
+++ b/frontend/src/components/organisms/userTeaser.tsx
@@ -24,11 +24,13 @@ const UserTeaser = (user: SocialTypes.User) => {
           />
         </div>
       )}
-      <header className="flex cursor-pointer items-center justify-between">
+      <header className="flex cursor-pointer flex-wrap-reverse items-center justify-between gap-3">
         <Typography variant="h5">
           <strong onClick={onOpenUser}>{user.firstName}</strong>
         </Typography>
-        <UserTeaserReduced {...user} />
+        <div className="ml-auto">
+          <UserTeaserReduced {...user} />
+        </div>
       </header>
       <footer className="flex justify-end" onClick={onOpenUser}>
         <UserCounters followers={user.numFollowers} posts={user.numPosts} />

--- a/frontend/src/layout/navbar.tsx
+++ b/frontend/src/layout/navbar.tsx
@@ -58,8 +58,8 @@ const AppNavbar = () => {
         <Divider className="hidden md:block" />
 
         <section className="flex gap-5 sm:gap-8 md:block">
-          <NavLink to="/home" icon={<HomeOutlined />} title="Home" />
-          <NavLink to="/feed" icon={<ImageOutlined />} title="Feed" />
+          <NavLink to="/home" icon={<HomeOutlined />} title="Inicio" />
+          <NavLink to="/feed" icon={<ImageOutlined />} title="Contenido" />
           <NavLink to="/explore" icon={<ExploreOutlined />} title="Explora" />
           <NavLink
             to="/notifications"

--- a/frontend/src/pages/explore.tsx
+++ b/frontend/src/pages/explore.tsx
@@ -117,8 +117,8 @@ const ExploreSection = (props: {
         hasData={!!props.slides.length}
       />
       <Carousel
-        duration={1000}
-        interval={5000}
+        duration={1500}
+        interval={7500}
         animation="slide"
         className="hidden lg:block"
       >
@@ -129,8 +129,8 @@ const ExploreSection = (props: {
         ))}
       </Carousel>
       <Carousel
-        duration={1000}
-        interval={5000}
+        duration={1500}
+        interval={7500}
         animation="slide"
         className="lg:hidden"
       >

--- a/frontend/src/pages/feed.tsx
+++ b/frontend/src/pages/feed.tsx
@@ -36,7 +36,7 @@ const FeedPage = () => {
   }, [params, refetch]);
 
   return (
-    <Page title="Feed">
+    <Page title="Contenido">
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <Typography variant="h5">Últimos posts</Typography>

--- a/frontend/src/pages/goalDetails.tsx
+++ b/frontend/src/pages/goalDetails.tsx
@@ -142,7 +142,7 @@ const GoalTabs = (props: { activeTab: string; goal: GoalTypes.Goal }) => {
       {activeTab === "info" && <GoalInfoTab {...goal} />}
       {activeTab === "trackings" && <GoalTrackingsTab {...goal} />}
       {activeTab === "feed" && <GoalFeedTab {...goal} />}
-      {activeTab === "leaderboard" && <GoalLeaderboardTab />}
+      {activeTab === "leaderboard" && <GoalLeaderboardTab {...goal} />}
       {activeTab === "stats" && <GoalStatsTab />}
     </section>
   );

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -36,7 +36,7 @@ const HomePage = () => {
   }, [params, refetch, setSearchParams]);
 
   return (
-    <Page title="Home">
+    <Page title="Inicio">
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <Typography variant="h5">Mis objetivos</Typography>

--- a/frontend/src/services/goalService.ts
+++ b/frontend/src/services/goalService.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 import { useInfiniteQuery, useMutation, useQuery } from "react-query";
 
-import { GoalTypes } from "types";
+import { GoalTypes, SocialTypes } from "types";
 import { Id, PagedList } from "types/apiTypes";
 import { paginationUtils } from "utils";
 
@@ -34,6 +34,21 @@ const requests = {
           (id || "missing") +
           "/my-progress?user_id=" +
           (participantId || "missing")
+      )
+      .then((response) => response.data),
+
+  getGoalLeaderboard: (
+    id?: Id,
+    frequency?: GoalTypes.Frequency,
+    page?: number
+  ) =>
+    axiosInstance
+      .get(
+        "/goal/" +
+          (id || "missing") +
+          "/leaderboard?frequency=" +
+          (frequency || "missing") +
+          (page ? "&page=" + page : "")
       )
       .then((response) => response.data),
 
@@ -149,6 +164,20 @@ const goalService = {
   useMyGoalProgress: (id?: Id, participantId?: Id) =>
     useQuery<GoalTypes.Progress, AxiosError>(`goal-${id}-my-progress`, () =>
       requests.getGoalProgressByParticipant(id, participantId)
+    ),
+
+  // Use goal leaderboard specifying its id
+  useGoalLeaderboard: (id?: Id, frequency?: GoalTypes.Frequency) =>
+    useInfiniteQuery<
+      PagedList<SocialTypes.User & { amount: number }>,
+      AxiosError
+    >(
+      `goal-${id}-leaderboard`,
+      ({ pageParam = 0 }) =>
+        requests.getGoalLeaderboard(id, frequency, pageParam),
+      {
+        getNextPageParam: paginationUtils.getNextPage,
+      }
     ),
 
   // Create a goal

--- a/goals/views.py
+++ b/goals/views.py
@@ -8,6 +8,7 @@ from auth.permissions import IsOwnerOrReadOnly, IsParticipating
 from goals.models import Goal, Objective, Tracking, Frequency
 from goals.serializers import GoalSerializer, ObjectiveSerializer, TrackingSerializer
 from social.models import Participate, LikeTracking, User
+from social.serializers import UserSerializer
 from utils.filters import FilterSet
 
 # ViewSet views
@@ -111,10 +112,12 @@ class LeaderBoard(viewsets.GenericAPIView):
 
         users = {}
         for tracking in trackings:
-            if tracking.createdBy.id in users:
-                users[tracking.createdBy.username] += tracking.amount
+            if tracking.createdBy.username in users:
+                users[tracking.createdBy.username]['amount'] += tracking.amount
             else:
-                users[tracking.createdBy.username] = tracking.amount
-        users = dict(sorted(users.items(), key=lambda x: x[1], reverse=True))
+                user = UserSerializer(tracking.createdBy).data
+                user['amount'] = tracking.amount
+                users[tracking.createdBy.username] = user
+        users = dict(sorted(users.items(), key=lambda x: x[1]['amount'], reverse=True))
 
-        return Response(users, status=200)
+        return Response(users.values(), status=200)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -41,7 +41,10 @@ def get_trackings(progress, goal, user, today, start_week, end_week):
         return []
 
 
-def set_amount(user):
+def set_amount(user, amount):
     user = UserSerializer(user).data
-    user['amount'] = 0.0
+    if amount:
+        user['amount'] = amount
+    else:
+        user['amount'] = 0.0
     return user

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,5 +1,7 @@
 from django.http import Http404
 
+from goals.models import Tracking, Frequency
+
 
 def get_obj_or_404(klass, *args, **kwargs):
     try:
@@ -14,3 +16,25 @@ def handle_uploaded_file(f):
         for chunk in f.chunks():
             destination.write(chunk)
     return url
+
+
+def get_trackings(progress, goal, user, today, start_week, end_week):
+    trackings = Tracking.objects
+    if user:
+        trackings = trackings.filter(createdBy=user)
+
+    if Frequency.TOTAL in progress:
+        return trackings.filter(goal=goal)
+    elif Frequency.YEARLY in progress:
+        return trackings.filter(goal=goal, date__lte=today.replace(month=12, day=31),
+                                date__gte=today.replace(month=1, day=1))
+    elif Frequency.MONTHLY in progress:
+        return trackings.filter(goal=goal, date__lte=today.replace(day=31),
+                                date__gte=today.replace(day=1))
+    elif Frequency.WEEKLY in progress:
+        return trackings.filter(goal=goal, date__lte=end_week,
+                                date__gte=start_week)
+    elif Frequency.DAILY in progress:
+        return trackings.filter(goal=goal, date__gte=today)
+    else:
+        return []

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,6 +1,7 @@
 from django.http import Http404
 
 from goals.models import Tracking, Frequency
+from social.serializers import UserSerializer
 
 
 def get_obj_or_404(klass, *args, **kwargs):
@@ -38,3 +39,9 @@ def get_trackings(progress, goal, user, today, start_week, end_week):
         return trackings.filter(goal=goal, date__gte=today)
     else:
         return []
+
+
+def set_amount(user):
+    user = UserSerializer(user).data
+    user['amount'] = 0.0
+    return user


### PR DESCRIPTION
# Cambios
- Nuevo endpoint de leaderboard por Goal y frecuencia
- Nueva función del utils reutilizable para el calculo de trackings por frecuencia
- Minor refactor del endpoint de progreso
# Test
- Comprobar que al hacer una petición al endpoint de a continuación se recibe un diccionario con los usuarios que han trackeado en ese goal para esa frecuencia ordenados por la cantidad trackeada
http://localhost:8000/api/goal/62e673bf7117d7d9c5df1726/leader-board?frequency=total
