### PR TITLE
#118-refactor: Ordenados objetivos por frecuencia

### DIFF
--- a/goals/serializers.py
+++ b/goals/serializers.py
@@ -2,6 +2,7 @@ from rest_framework_mongoengine import serializers
 
 from goals.models import Goal, Objective, Tracking
 from social.models import LikeTracking, Participate, Post
+from utils.utils import get_frequency_order
 
 
 class GoalSerializer(serializers.DocumentSerializer):
@@ -17,6 +18,7 @@ class GoalSerializer(serializers.DocumentSerializer):
 
     def get_objectives(self, obj):
         objectives = Objective.objects.filter(goal=obj)
+        objectives = sorted(objectives, key=lambda x: get_frequency_order(x.frequency))
         return ObjectiveSerializer(objectives, many=True).data
 
     def get_numParticipants(self, obj):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -48,3 +48,11 @@ def set_amount(user, amount):
     else:
         user['amount'] = 0.0
     return user
+
+
+frequency_order = {Frequency.DAILY: 0, Frequency.WEEKLY: 1, Frequency.MONTHLY: 2, Frequency.YEARLY: 3,
+                   Frequency.TOTAL: 4}
+
+
+def get_frequency_order(frequency):
+    return frequency_order[frequency]


### PR DESCRIPTION
# Cambios
- Modificado el Serializer de goal para que muestre sus objetivos asociados ordenados por frecuencia
- Nueva función del utils.py para obtener el orden que ocupa cada frecuencia
# Test
- Hacer una petición al endpoint de goals y comprobar que estos salen de manera ordenada